### PR TITLE
Fixing deprecated syntax on GET 'admin' spec.

### DIFF
--- a/spec/controllers/admin_spec.rb
+++ b/spec/controllers/admin_spec.rb
@@ -16,7 +16,7 @@ describe AdminController do
   describe "GET 'admin'" do
     it "should be successful" do
       get 'index'
-      response.should be_success
+      expect(response).to be_success
     end
   end
 


### PR DESCRIPTION
Fixed deprecated syntax ''response.should be_success"

The error message on spec was:

> Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /home/raphael/rails-projects/rails-chatbot/spec/controllers/admin_spec.rb:19:in `block (3 levels) in <top (required)>'.
